### PR TITLE
Add link and image to hosted website to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Real World Testing with Cypress
 
-Real World Testing with Cypress is a free and open source testing curriculum built with [Next.js](https://nextjs.org) by the team at [Cypress](https://www.cypress.io/).
+Real World Testing with Cypress is a free and open source testing curriculum built with [Next.js](https://nextjs.org) by the team at [Cypress](https://www.cypress.io/). Start learning today at [learn.cypress.io](https://learn.cypress.io/)
+
+<a href="https://learn.cypress.io/">
+  <img width="1384" alt="Screen Shot 2022-03-23 at 11 44 30 AM" src="https://user-images.githubusercontent.com/1271364/159762994-cf77ccad-307b-4d93-9871-b0452f967df4.png">
+</a>
 
 ## Installation
 


### PR DESCRIPTION
Add a link to the website where this repo is hosted as well as a visual banner to make it clearer which site this is. It's hard to tell without this repo this is the 'realworld app' repo or whether this is something else just from the Readme.

<img width="570" alt="Screen Shot 2022-03-23 at 11 49 10 AM" src="https://user-images.githubusercontent.com/1271364/159763754-30236566-dbd9-494e-8d76-db9e3dc998cf.png">
