### PR TITLE
Update paths to Practice and Answers specs for Cypress 10

### DIFF
--- a/content/courses/advanced-cypress-concepts/intercepting-network-requests.mdx
+++ b/content/courses/advanced-cypress-concepts/intercepting-network-requests.mdx
@@ -111,6 +111,6 @@ To learn more check out these resources in our docs:
 
 If you would like to practice intercepting Network Requests and working with the Network in general with Cypress, we have created a special repo which can be found [here](https://github.com/cypress-io/cypress-realworld-testing-blog). The installation instructions are located in the **README.md** file.
 
-The practice file you are looking for can be found in **cypress/integration/Practice/network-requests.spec.js**.
+The practice file you are looking for can be found in **cypress/e2e/Practice/network-requests.spec.js**.
 
-Should you get stuck or need some help, all of the answers are provided within **cypress/integration/Answers/network-requests.spec.js**
+Should you get stuck or need some help, all of the answers are provided within **cypress/e2e/Answers/network-requests.spec.js**


### PR DESCRIPTION
With Cypress 10, the spec files now live under cypress/e2e, not cypress/integration any longer.