### PR TITLE
Update file path in the practice examples

### DIFF
--- a/content/courses/advanced-cypress-concepts/building-the-right-cypress-commands.mdx
+++ b/content/courses/advanced-cypress-concepts/building-the-right-cypress-commands.mdx
@@ -71,6 +71,6 @@ describe("POST /login", () => {
 
 If you would like to practice how to build custom Cypress Commands, we have created a special repo which can be found [here](https://github.com/cypress-io/cypress-realworld-testing-blog). The installation instructions are located in the **README.md** file.
 
-The practice file you are looking for can be found in **cypress/integration/Practice/cypress-commands.spec.js**.
+The practice file you are looking for can be found in **cypress/e2e/Practice/cypress-commands.spec.js**.
 
-Should you get stuck or need some help, all of the answers are provided within **cypress/integration/Answers/cypress-commands.spec.js**
+Should you get stuck or need some help, all of the answers are provided within **cypress/e2e/Answers/cypress-commands.spec.js**

--- a/content/courses/advanced-cypress-concepts/important-cypress-methods-you-need-to-know.mdx
+++ b/content/courses/advanced-cypress-concepts/important-cypress-methods-you-need-to-know.mdx
@@ -91,6 +91,6 @@ You can find out more about `.within()` on our [API docs page](https://docs.cypr
 
 If you would like to practice using some of these Cypress methods, we have created a special repo which can be found [here](https://github.com/cypress-io/cypress-realworld-testing-blog). The installation instructions are located in the **README.md** file.
 
-The practice file you are looking for can be found in **cypress/integration/Practice/cypress-methods.spec.js**.
+The practice file you are looking for can be found in **cypress/e2e/Practice/cypress-methods.spec.js**.
 
-Should you get stuck or need some help, all of the answers are provided within **cypress/integration/Answers/cypress-methods.spec.js**
+Should you get stuck or need some help, all of the answers are provided within **cypress/e2e/Answers/cypress-methods.spec.js**

--- a/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
+++ b/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
@@ -56,9 +56,9 @@ it("comments on a transaction", () => {
 
 If you would like to practice how to to use JavaScript in Cypress, we have created a special repo which can be found [here](https://github.com/cypress-io/cypress-realworld-testing-blog). The installation instructions are located in the **README.md** file.
 
-The practice file you are looking for can be found in **cypress/integration/Practice/just-javascript.spec.js**.
+The practice file you are looking for can be found in **cypress/e2e/Practice/just-javascript.spec.js**.
 
-Should you get stuck or need some help, all of the answers are provided within **cypress/integration/Answers/just-javascript.spec.js**
+Should you get stuck or need some help, all of the answers are provided within **cypress/e2e/Answers/just-javascript.spec.js**
 
 ## Wrap Up
 

--- a/content/courses/cypress-fundamentals/how-to-debug-failing-tests.mdx
+++ b/content/courses/cypress-fundamentals/how-to-debug-failing-tests.mdx
@@ -46,6 +46,6 @@ Since Cypress runs in the browser, you have full access to all of the informatio
 
 If you would like to practice how to debug failing tests in Cypress, we have created a special repo which can be found [here](https://github.com/cypress-io/cypress-realworld-testing-blog). The installation instructions are located in the **README.md** file.
 
-The practice file you are looking for can be found in **cypress/integration/Practice/debug-failing-tests.spec.js**.
+The practice file you are looking for can be found in **cypress/e2e/Practice/debug-failing-tests.spec.js**.
 
-Should you get stuck or need some help, all of the answers are provided within **cypress/integration/Answers/debug-failing-tests.spec.js**
+Should you get stuck or need some help, all of the answers are provided within **cypress/e2e/Answers/debug-failing-tests.spec.js**


### PR DESCRIPTION
Update the file path in practice examples to be cypress/e2e instead of cypress/integration