### PR TITLE
Update fix forEach code example typo

### DIFF
--- a/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
+++ b/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
@@ -32,27 +32,27 @@ This example comes from the [Real World App](https://github.com/cypress-io/cypre
 Here is another example where we use [Array.forEach()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) to iterate over an array.
 
 ```js
-const people = ['moe', 'curly', 'larry'];
+const people = ["moe", "curly", "larry"]
 // Use method from lodash to get a person to use in a comment
-const transactions = [{ id: 1 }];
+const transactions = [{ id: 1 }]
 _.each(transactions, () => {
-  it('comments on a transaction', () => {
-    cy.getBySelLike('transaction-item').first().click();
-    cy.wait('@getTransaction');
+  it("comments on a transaction", () => {
+    cy.getBySelLike("transaction-item").first().click()
+    cy.wait("@getTransaction")
 
-    const comments = ['Thank you!', 'Appreciate it.'];
+    const comments = ["Thank you!", "Appreciate it."]
 
     comments.forEach((comment, index) => {
-      cy.getBySelLike('comment-input').type(`${comment}{enter}`);
-      cy.getBySelLike('comments-list').children().eq(index).contains(comment);
-    });
+      cy.getBySelLike("comment-input").type(`${comment}{enter}`)
+      cy.getBySelLike("comments-list").children().eq(index).contains(comment)
+    })
 
-    cy.getBySelLike('comments-list')
+    cy.getBySelLike("comments-list")
       .children()
-      .should('have.length', comments.length);
-    cy.visualSnapshot('Comment on Transaction');
-  });
-});
+      .should("have.length", comments.length)
+    cy.visualSnapshot("Comment on Transaction")
+  })
+})
 ```
 
 ## Practice

--- a/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
+++ b/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
@@ -32,25 +32,27 @@ This example comes from the [Real World App](https://github.com/cypress-io/cypre
 Here is another example where we use [Array.forEach()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) to iterate over an array.
 
 ```js
-const people = ["moe", "curly", "larry"]
+const people = ['moe', 'curly', 'larry'];
 // Use method from lodash to get a person to use in a comment
-const transactions = [{ id: 1 }]
-_.each(transaction,
-it("comments on a transaction", () => {
-    cy.getBySelLike("transaction-item").first().click();
-    cy.wait("@getTransaction");
+const transactions = [{ id: 1 }];
+_.each(transactions, () => {
+  it('comments on a transaction', () => {
+    cy.getBySelLike('transaction-item').first().click();
+    cy.wait('@getTransaction');
 
-    const comments = ["Thank you!", "Appreciate it."];
+    const comments = ['Thank you!', 'Appreciate it.'];
 
     comments.forEach((comment, index) => {
-      cy.getBySelLike("comment-input").type(`${comment}{enter}`);
-      cy.getBySelLike("comments-list").children().eq(index).contains(comment);
+      cy.getBySelLike('comment-input').type(`${comment}{enter}`);
+      cy.getBySelLike('comments-list').children().eq(index).contains(comment);
     });
 
-    cy.getBySelLike("comments-list").children().should("have.length", comments.length);
-    cy.visualSnapshot("Comment on Transaction");
+    cy.getBySelLike('comments-list')
+      .children()
+      .should('have.length', comments.length);
+    cy.visualSnapshot('Comment on Transaction');
   });
-  );
+});
 ```
 
 ## Practice

--- a/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
+++ b/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
@@ -50,6 +50,7 @@ it("comments on a transaction", () => {
     cy.getBySelLike("comments-list").children().should("have.length", comments.length);
     cy.visualSnapshot("Comment on Transaction");
   });
+  );
 ```
 
 ## Practice


### PR DESCRIPTION
In the forEach code example, when copying out it is missing the closing parenthesis for the _.each(transaction, line of code. I propose we add the closing parenthesis in case users are following along and copy the code block.