### PR TITLE
Replace 'index.ts' with 'index.d.ts' for namespace declaration

### DIFF
--- a/content/courses/testing-your-first-application/how-to-test-forms-and-custom-cypress-commands.mdx
+++ b/content/courses/testing-your-first-application/how-to-test-forms-and-custom-cypress-commands.mdx
@@ -28,7 +28,7 @@ Cypress.Commands.add("getByData", (selector) => {
 
 :::warning
 
-Since we are using TypeScript, you may get some errors from the compiler saying that it is unable to detect the types in our custom command. You can fix this, by creating the file `cypress/support/index.ts` and adding the following:
+Since we are using TypeScript, you may get some errors from the compiler saying that it is unable to detect the types in our custom command. You can fix this, by creating the file `cypress/support/index.d.ts` and adding the following:
 
 :::
 


### PR DESCRIPTION
If the namespace declaration is put into `index.ts` file it is not detected by TS properly. Putting it into index.d.ts file fixes the issue and TS stops complaining.