### PR TITLE
fix: yarn install dev instructions

### DIFF
--- a/content/tutorials/next-js-and-shopify-store/writing-end-to-end-tests-with-cypress.mdx
+++ b/content/tutorials/next-js-and-shopify-store/writing-end-to-end-tests-with-cypress.mdx
@@ -10,7 +10,7 @@ You can find our more about Cypress and how to install it on our [docs site](htt
 
 ```bash
 cd site
-yarn add cypress --save-dev
+yarn add cypress --dev
 ```
 
 Open up the `package.json` file and add the following scripts.


### PR DESCRIPTION
This PR fixes the instructions to install cypress as a dev dependency with yarn.

`--save-dev` is only the correct switch for `npm` and `pnpm`, not for `yarn`

`yarn` needs `--dev` not `--save-dev`

## Reference

https://classic.yarnpkg.com/en/docs/cli/add#toc-yarn-add-dev-d

```text
yarn add <package...> [--dev/-D]
Using --dev or -D will install one or more packages in your devDependencies.
```
