### PR TITLE
replace ssh clone instructions with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Real World Testing with Cypress is a free and open source testing curriculum bui
 ## Installation
 
 ```bash
-git clone git@github.com:cypress-io/cypress-realworld-testing.git
+git clone https://github.com/cypress-io/cypress-realworld-testing.git
 
 cd cypress-realworld-testing
 

--- a/content/courses/testing-your-first-application/app-install-and-overview.mdx
+++ b/content/courses/testing-your-first-application/app-install-and-overview.mdx
@@ -26,7 +26,7 @@ Running this command will download the repo on the “start” branch. It is ver
 :::
 
 ```bash
-git clone --branch start git@github.com:cypress-io/cypress-realworld-testing-course-app.git
+git clone --branch start https://github.com/cypress-io/cypress-realworld-testing-course-app.git
 ```
 
 ### Downloading a zip file

--- a/content/real-world-examples/overview/cypress-real-world-app-overview.mdx
+++ b/content/real-world-examples/overview/cypress-real-world-app-overview.mdx
@@ -9,7 +9,7 @@ You can find the repo [here](https://github.com/cypress-io/cypress-realworld-app
 You can clone the repo via the command line with:
 
 ```bash
-git clone git@github.com:cypress-io/cypress-realworld-app.git
+git clone https://github.com/cypress-io/cypress-realworld-app.git
 ```
 
 It might be best to first fork a copy of the repo and then clone the forked version.


### PR DESCRIPTION
This PR resolves #278 executing the cloning instructions on https://learn.cypress.io/testing-your-first-application/app-install-and-overview resulting in the error "Permission denied (publickey).".

## Issue

These are the current problematic instructions:

---
## Cloning with Git

If you are familiar with Git and already have it installed the easiest way to clone the repo is to run this command in your terminal.

```bash
git clone --branch start git@github.com:cypress-io/cypress-realworld-testing-course-app.git
```
---
This may result in a failure to clone the course contents:

```text
$ git clone --branch start git@github.com:cypress-io/cypress-realworld-testing-course-app.git
Cloning into 'cypress-realworld-testing-course-app'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

The cloning instructions use `SSH` syntax and require an `SSH` certificate to work. This is not described in the instructions.

## Change

The instructions are changed to use the `https` protocol, which is widely available and requires no other preparation:

Previously

`git clone ... git@github.com:cypress-io/...` 

changed to 

`git clone ... https://github.com/cypress-io/...`


This is applied to all occurrences in the repo.