### PR TITLE
Correct Node.js and npm spelling

### DIFF
--- a/content/courses/testing-your-first-application/app-install-and-overview.mdx
+++ b/content/courses/testing-your-first-application/app-install-and-overview.mdx
@@ -40,7 +40,7 @@ Next, click on the green “Code” button and then click on “Download ZIP.”
 
 ## Installing the application
 
-Now that you have either cloned the repo or downloaded it, you will need to install all of the npm packages and dependencies. You will need to install [NodeJS](https://nodejs.org/en/) if you don’t have it already installed on your computer. You want to make sure that you download the “LTS” version of Node and not the “Current” version.
+Now that you have either cloned the repo or downloaded it, you will need to install all of the npm packages and dependencies. You will need to install [Node.js](https://nodejs.org/en/) if you don’t have it already installed on your computer. You want to make sure that you download the “LTS” version of Node and not the “Current” version.
 
 This repo will be updated regularly to support the latest LTS versions only.
 
@@ -52,7 +52,7 @@ Within VSCode, you can open the repo via File > Open Folder
 
 ![Screen Shot 2022-06-28 at 8.12.25 AM.png](/images/testing-your-first-application/app-install-and-overview/Screen_Shot_2022-06-28_at_8.12.25_AM.png)
 
-Now that you have the application opened inside of VSCode we can use the built-in terminal to install our NPM packages.
+Now that you have the application opened inside of VSCode we can use the built-in terminal to install our npm packages.
 
 You can open the terminal via Terminal > New Terminal
 
@@ -60,9 +60,9 @@ You can open the terminal via Terminal > New Terminal
 
 ![Screen Shot 2022-06-28 at 8.14.17 AM.png](/images/testing-your-first-application/app-install-and-overview/Screen_Shot_2022-06-28_at_8.14.17_AM.png)
 
-## Installing our NPM dependencies
+## Installing our npm dependencies
 
-Before we install our dependencies let's make sure we are running the correct version of NodeJS.
+Before we install our dependencies let's make sure we are running the correct version of Node.js.
 
 In the terminal type the following and then press enter
 
@@ -70,11 +70,11 @@ In the terminal type the following and then press enter
 node -v
 ```
 
-The terminal should output the same version as the LTS version of NodeJS you downloaded.
+The terminal should output the same version as the LTS version of Node.js you downloaded.
 
 ![Screen Shot 2022-06-28 at 8.16.50 AM.png](/images/testing-your-first-application/app-install-and-overview/Screen_Shot_2022-06-28_at_8.16.50_AM.png)
 
-Then type the following to install all of our NPM dependencies.
+Then type the following to install all of our npm dependencies.
 
 ```bash
 npm install
@@ -130,7 +130,7 @@ At the very bottom of each lesson is a quiz. In this application, the correct an
 
 ## Wrap up
 
-In this lesson, you learned how to install the course application either via Git or by downloading a zip file. Next, you learned how to install NodeJS, VSCode, and the application dependencies via NPM. After installing everything, you learned how to launch the app’s dev server on `localhost:3000`
+In this lesson, you learned how to install the course application either via Git or by downloading a zip file. Next, you learned how to install Node.js, VSCode, and the application dependencies via npm. After installing everything, you learned how to launch the app’s dev server on `localhost:3000`
 
 Finally, you learned the various pages and functionality of the app. You should now have a basic understanding of what the app is, how it works, some of its core functionality, etc.
 


### PR DESCRIPTION
This PR aligns the spelling of `Node.js` and `npm` to the product owner's documentation.

- According to [npm Docs](https://docs.npmjs.com/) (Documentation for the npm registry, website, and command-line interface) the product is written lower case `npm`, not `NPM`.

- Referring to the [Node.js documentation](https://nodejs.org/en/docs) the term is consistently referred to as `Node.js`. This is also confirmed in the [Node.js Style Guide](https://github.com/nodejs/node/blob/main/doc/README.md). The form `NodeJS` is not used in the official documentation.
