### PR TITLE
Align to Cypress default template spec

### DIFF
--- a/content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx
+++ b/content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx
@@ -73,7 +73,7 @@ Open the `cypress/e2e/home.cy.ts` file in VSCode.
 This is the default test that Cypress created when we asked it to create our spec file. We need to update it to run tests against our course application, but before we do that, let's break down the code that is in this file.
 
 ```jsx
-describe("empty spec", () => {
+describe("template spec", () => {
   it("passes", () => {
     cy.visit("https://example.cypress.io")
   })
@@ -83,7 +83,7 @@ describe("empty spec", () => {
 On the first line, we see what is commonly referred to as a “describe block.”
 
 ```jsx
-describe("empty spec", () => {})
+describe("template spec", () => {})
 ```
 
 The `describe()` function takes two arguments. The first is a string which is a description of the tests contained within it. The second is a [callback function](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function). Since this file is going to contain tests for our home page, let's update this to say “home page.”


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress-realworld-testing-course-app/issues/26

This PR updates [Testing Your First Application > Installing Cypress and writing your first test](https://learn.cypress.io/testing-your-first-application/installing-cypress-and-writing-your-first-test).

The Cypress default template derives from [empty.ejs](https://github.com/cypress-io/cypress/blob/develop/packages/data-context/src/codegen/templates/empty-e2e/empty.ejs) which uses a describe text 'template spec' and single quotes:

```js
---
fileName: <%= fileName %>
---

describe('template spec', () => {
  it('passes', () => {
    cy.visit('https://example.cypress.io')
  })
```

The text is changed in the training materials to match the default template text 'template spec' from Cypress `12.14.0` and later.

The double quotes are left unchanged. These are used in too many places to want to change them.