### PR TITLE
Fixed issued #326 - UI Issue: Lesson Content Overlaps Sidebar on Learn Cypress

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -73,6 +73,7 @@ input[type="search"]:focus {
 
 .pro-sidebar {
   width: 100% !important;
+  min-width: auto;
 }
 
 .pro-sidebar .pro-arrow-wrapper {


### PR DESCRIPTION
Fixed this issue:
UI Issue: Lesson Content Overlaps Sidebar on Learn Cypress #326 https://github.com/cypress-io/cypress-realworld-testing/issues/326