### PR TITLE
Fix stop-only path and surfaced multiple-choice spec issues

### DIFF
--- a/cypress/e2e/multiple-choice-challenge.cy.ts
+++ b/cypress/e2e/multiple-choice-challenge.cy.ts
@@ -5,10 +5,9 @@ describe("Multiple Choice Challenge", () => {
 
   it("gray's out and strikes through an incorrect answer", () => {
     cy.get("#answer-0").click()
-    cy.get("label[for='answer-0']").should(
-      "have.class",
-      "line-through text-gray-300"
-    )
+    cy.get("label[for='answer-0']")
+      .should("have.class", "line-through")
+      .and("have.class", "text-gray-300")
   })
 
   it("it displays the next lesson button when an answer is correct and updates the progress sidebar", () => {
@@ -38,7 +37,7 @@ describe("Multiple Choice Challenge", () => {
       cy.getBySel("multiple-choice-challenge").should("be.visible")
     })
 
-    it.only("displays the complete lesson button when checked", () => {
+    it("displays the complete lesson button when checked", () => {
       cy.getBySel("skip-challenge-input").click()
       cy.getBySel("complete-lesson-button").should("be.visible")
       cy.getBySel("next-lesson-button").should("not.exist")

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "next start",
     "update-rwe-slugs": "ts-node scripts/updateRWESlugs.ts",
     "update-slugs": "ts-node scripts/updateSlugs.ts",
-    "stop-only": "stop-only --folder cypress/integration",
+    "stop-only": "stop-only --folder cypress/e2e",
     "test:unit": "mocha -r ts-node/register -r tsconfig-paths/register 'tests/**/*.ts'",
     "types": "tsc --noEmit",
     "update-algolia-index": "yarn create-search-index && ts-node scripts/updateAlgoliaIndex.ts"


### PR DESCRIPTION
- Point stop-only at cypress/e2e (Cypress 10+ renamed the folder from
  cypress/integration), so the script and the pre-commit hook run again.
- Remove a stray it.only in multiple-choice-challenge.cy.ts that was
  silently skipping the other tests in the file.
- Fix the now-running "grays out" assertion: have.class takes a single
  class name, so split the combined string into separate assertions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TYS3CqbEiZrwDdQNhf65af