### PR TITLE
Update env handling docs/tests for Cypress 15.10+ env/expose APIs

### DIFF
--- a/content/courses/advanced-cypress-concepts/how-to-test-various-browsers-and-viewports.mdx
+++ b/content/courses/advanced-cypress-concepts/how-to-test-various-browsers-and-viewports.mdx
@@ -73,27 +73,29 @@ We also have a utility function called `isMobile()` which determines if our test
 export const isMobile = () => {
   return (
     Cypress.config("viewportWidth") <
-    Cypress.env("mobileViewportWidthBreakpoint")
+    Cypress.expose("mobileViewportWidthBreakpoint")
   )
 }
 ```
 
-The environment variable `mobileViewportWidthBreakpoint` is located within the `cypress.json` config file.
+The configuration value `mobileViewportWidthBreakpoint` is located within the `cypress.config.ts` config file. Because it is non-sensitive, public configuration, the RWA defines it under the `expose` key and reads it in tests with [Cypress.expose()](https://docs.cypress.io/api/cypress-api/expose) (Cypress 15.10.0+). Reserve the `env` key and [cy.env()](https://docs.cypress.io/api/commands/env) for secrets you want to keep out of the browser.
 
-```json
-{
+```ts
+export default defineConfig({
   // ...
 
-  "env": {
-    "apiUrl": "http://localhost:3001",
-    "mobileViewportWidthBreakpoint": 414,
-    "coverage": false,
-    "codeCoverage": {
-      "url": "http://localhost:3001/__coverage__"
-    }
+  expose: {
+    apiUrl: "http://localhost:3001",
+    mobileViewportWidthBreakpoint: 414,
+    coverage: false,
+    codeCoverage: {
+      url: "http://localhost:3001/__coverage__",
+    },
   },
-  "experimentalStudio": true
-}
+  e2e: {
+    experimentalStudio: true,
+  },
+})
 ```
 
 In our tests, we can use this function to determine if the tests are being executed within our mobile viewport and react accordingly using a conditional.

--- a/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
+++ b/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
@@ -21,7 +21,7 @@ _.each(feedViews, (feed, feedName) => {
 
         cy.wait(`@${feed.routeAlias}`)
           .its("response.body.results")
-          .should("have.length", Cypress.env("paginationPageSize"));
+          .should("have.length", Cypress.expose("paginationPageSize"));
 // ...
 ```
 

--- a/content/real-world-examples/bank-accounts/users-without-bank-accounts.mdx
+++ b/content/real-world-examples/bank-accounts/users-without-bank-accounts.mdx
@@ -43,7 +43,7 @@ Next, we use <apiLink apiName="intercept" displayName="cy.intercept()" /> to int
 Then we clear out any `listBankAccount` items that come back by setting this property on the response to an empty array. This is how we manipulate the response data to ensure we "render an empty bank account list," which is necessary for our test.
 
 ```js
-cy.intercept("POST", `${Cypress.env("apiUrl")}/graphql`, (req) => {
+cy.intercept("POST", `${Cypress.expose("apiUrl")}/graphql`, (req) => {
   const { body } = req
   if (
     body.hasOwnProperty("operationName") &&

--- a/content/real-world-examples/overview/custom-cypress-commands.mdx
+++ b/content/real-world-examples/overview/custom-cypress-commands.mdx
@@ -414,20 +414,27 @@ cy.wait("@loginUser").then((loginUser: any) => {
 Located in `cypress/support/commands.ts` .
 
 ```js
-Cypress.Commands.add(
-  "loginByApi",
-  (username, password = Cypress.env("defaultPassword")) => {
-    return cy.request("POST", `${Cypress.env("apiUrl")}/login`, {
+Cypress.Commands.add("loginByApi", (username, password) => {
+  const sendLogin = (pw) =>
+    cy.request("POST", `${Cypress.expose("apiUrl")}/login`, {
       username,
-      password,
+      password: pw,
     })
-  }
-)
+
+  return password !== undefined
+    ? sendLogin(password)
+    : cy
+        .env(["defaultPassword"])
+        .then(({ defaultPassword }) => sendLogin(defaultPassword))
+})
 ```
 
 This command logs in a user via one of our API endpoints. It takes the `username` and `password` and sends a `POST` request to our "/login" endpoint, and logs in our user.
 
-Note how we are using [Cypress.env()](https://docs.cypress.io/api/cypress-api/env) to handle our environment variables. You can find these in `cypres/plugins/index.ts` and `cypress.json`, respectively.
+Note how we handle our two kinds of configuration values differently (Cypress 15.10.0+):
+
+- `apiUrl` is non-sensitive, public configuration, so it lives under the `expose` key in `cypress.config.ts` and is read synchronously with [Cypress.expose()](https://docs.cypress.io/api/cypress-api/expose).
+- `defaultPassword` is a secret, so it lives under the `env` key and is read with [cy.env()](https://docs.cypress.io/api/commands/env), which resolves only the values you ask for and keeps them out of the browser. Because `cy.env()` is asynchronous, we fall back to it inside a `.then()` only when a `password` argument was not provided.
 
 ---
 
@@ -436,24 +443,23 @@ Note how we are using [Cypress.env()](https://docs.cypress.io/api/cypress-api/en
 Located in `cypress/support/commands.ts` .
 
 ```js
-Cypress.Commands.add(
-  "loginByXstate",
-  (username, password = Cypress.env("defaultPassword")) => {
-    const log = Cypress.log({
-      name: "loginbyxstate",
-      displayName: "LOGIN BY XSTATE",
-      message: [`🔐 Authenticating | ${username}`],
-      autoEnd: false,
-    })
+Cypress.Commands.add("loginByXstate", (username, password) => {
+  const log = Cypress.log({
+    name: "loginbyxstate",
+    displayName: "LOGIN BY XSTATE",
+    message: [`🔐 Authenticating | ${username}`],
+    autoEnd: false,
+  })
 
-    cy.intercept("POST", "/login").as("loginUser")
-    cy.intercept("GET", "/checkAuth").as("getUserProfile")
-    cy.visit("/signin", { log: false }).then(() => {
-      log.snapshot("before")
-    })
+  cy.intercept("POST", "/login").as("loginUser")
+  cy.intercept("GET", "/checkAuth").as("getUserProfile")
+  cy.visit("/signin", { log: false }).then(() => {
+    log.snapshot("before")
+  })
 
+  const doLogin = (pw) => {
     cy.window({ log: false }).then((win) =>
-      win.authService.send("LOGIN", { username, password })
+      win.authService.send("LOGIN", { username, password: pw })
     )
 
     cy.wait("@loginUser").then((loginUser) => {
@@ -461,36 +467,46 @@ Cypress.Commands.add(
         consoleProps() {
           return {
             username,
-            password,
+            password: pw,
             // @ts-ignore
             userId: loginUser.response.body.user.id,
           }
         },
       })
     })
-
-    return cy
-      .getBySel("list-skeleton")
-      .should("not.exist")
-      .then(() => {
-        log.snapshot("after")
-        log.end()
-      })
   }
-)
+
+  if (password !== undefined) {
+    doLogin(password)
+  } else {
+    cy.env(["defaultPassword"]).then(({ defaultPassword }) =>
+      doLogin(defaultPassword)
+    )
+  }
+
+  return cy
+    .getBySel("list-skeleton")
+    .should("not.exist")
+    .then(() => {
+      log.snapshot("after")
+      log.end()
+    })
+})
 ```
 
 A lot is going on in this custom command, but we will break it down step by step.
 
-First, the command expects a username or password when it is invoked. We are providing a default password by using [Cypress.env()](https://docs.cypress.io/api/cypress-api/env).
+First, the command accepts a `username` and an optional `password`. When no `password` is passed, we fall back to a seeded default. Because `defaultPassword` is a secret, it lives under the `env` key in `cypress.config.ts` and is read with [cy.env()](https://docs.cypress.io/api/commands/env) (Cypress 15.10.0+), which keeps it out of the browser and resolves only the values you request. Since `cy.env()` is asynchronous, we resolve the password inside a `.then()` and then continue logging in via the `doLogin` helper.
 
-This environment variable can be found in `cypress/plugins/index.ts` around line `15`.
+This environment variable can be found in `cypress.config.ts` under the `env` key.
 
 ```js
-config.env.defaultPassword = process.env.SEED_DEFAULT_USER_PASSWORD
+env: {
+  defaultPassword: process.env.SEED_DEFAULT_USER_PASSWORD,
+},
 ```
 
-On the left hand side we are setting the [Cypress.env()](https://docs.cypress.io/api/cypress-api/env) with our environment variable from the `.env` file in the root of the project around line `10`
+On the right hand side we are reading our environment variable from the `.env` file in the root of the project around line `10`
 
 ```js
 SEED_DEFAULT_USER_PASSWORD = s3cret
@@ -524,23 +540,23 @@ cy.visit("/signin", { log: false }).then(() => {
 
 Next, we log in our user by sending an event to the [XState](https://xstate.js.org/docs/) store, responsible for handling all of our client-side state around authentication. It is very similar to [Redux](https://redux.js.org/). The `authservice` is attached to the `window` object, so we use <apiLink apiName="window" displayName="cy.window()" /> to grab the `window` object from the browser. We intentionally expose this service to the `window` object so that Cypress has access to it. You can see an example of how we are doing this [here](https://github.com/cypress-io/cypress-realworld-app/blob/86bc319b33a98fc70a5c2e431e98307f5f28e532/src/containers/App.tsx#L17-L21).
 
-Then we trigger the `LOGIN` action with our username and password, which updates XState, and logs in the user.
+Then we trigger the `LOGIN` action with our username and the resolved password (`pw`), which updates XState, and logs in the user. This runs inside the `doLogin` helper so it works whether the password was passed in directly or resolved from `cy.env(["defaultPassword"])`.
 
 ```js
 cy.window({ log: false }).then((win) =>
-  win.authService.send("LOGIN", { username, password })
+  win.authService.send("LOGIN", { username, password: pw })
 )
 ```
 
 We are then using <apiLink apiName="wait" displayName="cy.wait()" /> on the `@loginUser` intercept alias and set some of the login data in our [Cypress.log()](https://docs.cypress.io/api/cypress-api/cypress-log) declared above.
 
 ```js
-return cy.wait("@loginUser").then((loginUser) => {
+cy.wait("@loginUser").then((loginUser) => {
     log.set({
       consoleProps() {
         return {
           username,
-          password,
+          password: pw,
           // @ts-ignore
           userId: loginUser.response.body.user.id,
         };
@@ -1036,36 +1052,38 @@ Located in `cypress/support/utils.ts` .
 export const isMobile = () => {
   return (
     Cypress.config("viewportWidth") <
-    Cypress.env("mobileViewportWidthBreakpoint")
+    Cypress.expose("mobileViewportWidthBreakpoint")
   )
 }
 ```
 
 This function is a utility function used throughout our Cypress tests to determine if the viewport is a mobile device or not.
 
-Both of the environment variables can be found inside the `cypress.json` file in the root of the repo.
+Both of these values can be found inside the `cypress.config.ts` file in the root of the repo. `mobileViewportWidthBreakpoint` is non-sensitive, public configuration, so it lives under the `expose` key and is read in tests with [Cypress.expose()](https://docs.cypress.io/api/cypress-api/expose) (Cypress 15.10.0+).
 
-```json
-{
-  "baseUrl": "http://localhost:3000",
-  "projectId": "7s5okt",
-  "integrationFolder": "cypress/tests",
-  "viewportHeight": 1000,
-  "viewportWidth": 1280, // Cypress.config("viewportWidth")
-  "retries": {
-    "runMode": 2,
-    "openMode": 1
+```ts
+export default defineConfig({
+  projectId: "7s5okt",
+  retries: {
+    runMode: 2,
+    openMode: 1,
   },
-  "env": {
-    "apiUrl": "http://localhost:3001",
-    "mobileViewportWidthBreakpoint": 414, // Cypress.env("mobileViewportWidthBreakpoint")
-    "coverage": false,
-    "codeCoverage": {
-      "url": "http://localhost:3001/__coverage__"
-    }
+  expose: {
+    apiUrl: "http://localhost:3001", // Cypress.expose("apiUrl")
+    mobileViewportWidthBreakpoint: 414, // Cypress.expose("mobileViewportWidthBreakpoint")
+    coverage: false,
+    codeCoverage: {
+      url: "http://localhost:3001/__coverage__",
+    },
   },
-  "experimentalStudio": true
-}
+  e2e: {
+    baseUrl: "http://localhost:3000",
+    specPattern: "cypress/tests/**/*.spec.{js,jsx,ts,tsx}",
+    viewportHeight: 1000,
+    viewportWidth: 1280, // Cypress.config("viewportWidth")
+    experimentalStudio: true,
+  },
+})
 ```
 
 This handy function will only be executed whenever our viewport width is less than `414px`.

--- a/content/real-world-examples/transaction-feeds/renders-transactions-item-variations-in-feed.mdx
+++ b/content/real-world-examples/transaction-feeds/renders-transactions-item-variations-in-feed.mdx
@@ -102,7 +102,7 @@ describe("renders and paginates all transaction feeds", () => {
 
         cy.wait(`@${feed.routeAlias}`)
           .its("response.body.results")
-          .should("have.length", Cypress.env("paginationPageSize"));
+          .should("have.length", Cypress.expose("paginationPageSize"));
 
         // Temporary fix: <https://github.com/cypress-io/cypress-realworld-app/issues/338>
         if (isMobile()) {
@@ -115,7 +115,7 @@ describe("renders and paginates all transaction feeds", () => {
         cy.wait(`@${feed.routeAlias}`)
           .its("response.body")
           .then(({ results, pageData }) => {
-            expect(results).have.length(Cypress.env("paginationPageSize"));
+            expect(results).have.length(Cypress.expose("paginationPageSize"));
             expect(pageData.page).to.equal(2);
             cy.visualSnapshot(`Paginate ${feedName} Next Page`);
             cy.nextTransactionFeedPage(feed.service, pageData.totalPages);

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,16 +6,19 @@ export default defineConfig({
   viewportHeight: 1000,
   viewportWidth: 1400,
   blockHosts: ['*.osano.com'], // blocking the cookie popup from tests
-  env: {
+  // Non-sensitive, public configuration belongs in `expose` and is read in
+  // tests with `Cypress.expose()` (Cypress 15.10.0+). Use the `env` key plus
+  // `cy.env()` only for sensitive values you want to keep out of the browser.
+  expose: {
     mobileViewportWidthBreakpoint: 414,
   },
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
-      config.env.siteURL = process.env.SITE_URL
+      config.expose.siteURL = process.env.SITE_URL
 
       return config
     },
-    
+
   },
 })

--- a/cypress/e2e/robots.cy.ts
+++ b/cypress/e2e/robots.cy.ts
@@ -11,13 +11,13 @@ if (Cypress.platform === "linux") {
     it("has the correct Host URL", function () {
       cy.request("/robots.txt")
         .its("body")
-        .should("contain", `Host: ${Cypress.env("siteURL")}`)
+        .should("contain", `Host: ${Cypress.expose("siteURL")}`)
     })
 
     it("has the correct url for the Sitemap", function () {
       cy.request("/robots.txt")
         .its("body")
-        .should("contain", `Sitemap: ${Cypress.env("siteURL")}`)
+        .should("contain", `Sitemap: ${Cypress.expose("siteURL")}`)
     })
   })
 }

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -1,6 +1,6 @@
 export const isMobile = () => {
   return (
     Cypress.config("viewportWidth") <
-    Cypress.env("mobileViewportWidthBreakpoint")
+    Cypress.expose("mobileViewportWidthBreakpoint")
   )
 }


### PR DESCRIPTION
Cypress 15.10.0 deprecated `Cypress.env()` in favor of two explicit APIs:
`Cypress.expose()` (sync) for non-sensitive, public configuration defined
under the `expose` config key, and `cy.env()` (async) for secrets defined
under the `env` config key and kept out of the browser. The upstream
cypress-realworld-app has already migrated, so update the course/example
content and this repo's own Cypress config and tests to match.

- cypress.config.ts: move public config to `expose`; set siteURL via
  config.expose in setupNodeEvents
- robots.cy.ts / utils.ts: read public values with Cypress.expose()
- custom-cypress-commands.mdx: migrate loginByApi/loginByXstate to
  Cypress.expose("apiUrl") + cy.env(["defaultPassword"]); update config
  examples from cypress.json to cypress.config.ts env/expose split
- other lessons/examples: replace Cypress.env() public reads with
  Cypress.expose()

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BMbvtTKqtSTVEYKpJJUyHY