### PR TITLE
docs: fix technical inaccuracies in Cypress tutorial content

### DIFF
--- a/content/courses/cypress-fundamentals/command-chaining.mdx
+++ b/content/courses/cypress-fundamentals/command-chaining.mdx
@@ -12,7 +12,7 @@ cy.get(".todo-list li").find("label").should("contain", "Buy Milk")
 
 In this example, <apiLink apiName="get" displayName="cy.get()" /> will yield the `<li>` subject to <apiLink apiName="find" displayName=".find()" /> which will then search for the `<label>` element. Finally, we make an assertion that the `<label>` contains the text "Buy Milk."
 
-However, it is important to note that not all Cypress commands yield a subject that can be chained. For instance, <apiLink apiName="clearcookies" displayName="cy.clearCookies()" /> yields `null`, which _cannot_ be chained.
+However, it is important to note that not all Cypress commands yield a subject you can keep working with. For instance, <apiLink apiName="clearcookies" displayName="cy.clearCookies()" /> yields `null`, so there is no element to chain assertions onto.
 
 Cypress commands like <apiLink apiName="get" displayName="cy.get()" /> and <apiLink apiName="contains" displayName="cy.contains()" /> yield DOM elements that can be chained, like in the example above.
 

--- a/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
+++ b/content/courses/cypress-fundamentals/cypress-is-just-javascript.mdx
@@ -15,7 +15,7 @@ _.each(feedViews, (feed, feedName) => {
           .click()
           .should("have.class", "Mui-selected")
           .contains(feed.tabLabel, { matchCase: false })
-          .should("have.css", { "text-transform": "uppercase" });
+          .should("have.css", "text-transform", "uppercase");
         cy.getBySel("list-skeleton").should("not.exist");
         cy.visualSnapshot(`Paginate ${feedName}`);
 

--- a/content/courses/cypress-fundamentals/understanding-the-asynchronous-nature-of-cypress.mdx
+++ b/content/courses/cypress-fundamentals/understanding-the-asynchronous-nature-of-cypress.mdx
@@ -23,7 +23,7 @@ Cypress commands are asynchronous and get queued for execution at a later time. 
 
 So if a command does not **return** a subject but instead **yields** it, how can you interact with the subject directly? You can interact with a subject directly by using <apiLink apiName="then" displayName=".then()" />.
 
-`.then()` behaves similarly to Promises in JavaScript. However, <apiLink apiName="then" displayName=".then()" /> is a Cypress command, **not a Promise**. This means you cannot use things like **async/await** within your Cypress tests.
+`.then()` behaves similarly to Promises in JavaScript. However, <apiLink apiName="then" displayName=".then()" /> is a Cypress command, **not a Promise**. This means you cannot use **async/await** to wait on Cypress commands — use `.then()` to work with what a command yields instead.
 
 Whatever is returned from the callback function becomes the new subject and will flow into the following command (except for `undefined`).
 

--- a/content/courses/cypress-fundamentals/understanding-the-asynchronous-nature-of-cypress.mdx
+++ b/content/courses/cypress-fundamentals/understanding-the-asynchronous-nature-of-cypress.mdx
@@ -23,7 +23,7 @@ Cypress commands are asynchronous and get queued for execution at a later time. 
 
 So if a command does not **return** a subject but instead **yields** it, how can you interact with the subject directly? You can interact with a subject directly by using <apiLink apiName="then" displayName=".then()" />.
 
-`.then()` behaves similarly to Promises in JavaScript. However, <apiLink apiName="then" displayName=".then()" /> is a Cypress command, **not a Promise**. This means you cannot use **async/await** to wait on Cypress commands — use `.then()` to work with what a command yields instead.
+`.then()` behaves similarly to Promises in JavaScript. However, <apiLink apiName="then" displayName=".then()" /> is a Cypress command, **not a Promise**. This means you cannot use **async/await** to wait on Cypress commands. Use `.then()` to work with what a command yields instead.
 
 Whatever is returned from the callback function becomes the new subject and will flow into the following command (except for `undefined`).
 

--- a/content/courses/testing-foundations/the-testing-pyramid.mdx
+++ b/content/courses/testing-foundations/the-testing-pyramid.mdx
@@ -40,7 +40,7 @@ These types of tests are written to test anything that runs in the browser. The 
 
 For example, you might write a single test that registers a new account, logs in to that newly created account, purchases a product and then logs out. This way, you can ensure that all the layers within your application are working together correctly.
 
-End-to-end (E2E) tests overlap with integration tests, since both check that different parts of your application work together. The key difference is that integration tests usually verify a few pieces working together, while E2E tests exercise the whole application the way a real user would — which gives them an added advantage and value.
+End-to-end (E2E) tests overlap with integration tests, since both check that different parts of your application work together. The key difference is that integration tests usually verify a few pieces working together, while E2E tests exercise the whole application the way a real user would, which gives them an added advantage and value.
 
 ## Wrap Up
 

--- a/content/courses/testing-foundations/the-testing-pyramid.mdx
+++ b/content/courses/testing-foundations/the-testing-pyramid.mdx
@@ -40,7 +40,7 @@ These types of tests are written to test anything that runs in the browser. The 
 
 For example, you might write a single test that registers a new account, logs in to that newly created account, purchases a product and then logs out. This way, you can ensure that all the layers within your application are working together correctly.
 
-End-to-end (E2E) tests will often replace your integration tests, as they are essentially testing the same thing. However, E2E tests have an ever more significant advantage and value over integration tests, as they are testing real user interactions within your application.
+End-to-end (E2E) tests overlap with integration tests, since both check that different parts of your application work together. The key difference is that integration tests usually verify a few pieces working together, while E2E tests exercise the whole application the way a real user would — which gives them an added advantage and value.
 
 ## Wrap Up
 

--- a/content/courses/testing-your-first-application/how-to-test-multiple-pages.mdx
+++ b/content/courses/testing-your-first-application/how-to-test-multiple-pages.mdx
@@ -128,7 +128,7 @@ Now, we need to get the “Get started” button, however, there is a slight pro
 <div data-test="course-0"></div>
 ```
 
-We are now going to learn a new Cypress command that allows us to narrow down the scope in which Cypress looks for an element. We can tell Cypress to [find](https://docs.cypress.io/api/commands/find) elements that are within this element, ie: the elements direct children.
+We are now going to learn a new Cypress command that allows us to narrow down the scope in which Cypress looks for an element. We can tell Cypress to [find](https://docs.cypress.io/api/commands/find) elements that are nested anywhere within this element, ie: the element's descendants.
 
 ```ts
 context("Courses section", () => {

--- a/content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx
+++ b/content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx
@@ -437,14 +437,14 @@ You can see this in even greater detail by clicking on the step and then opening
 
 ![Screen Shot 2022-06-28 at 2.56.26 PM.png](/images/testing-your-first-application/installing-cypress-and-writing-your-first-test/Screen_Shot_2022-06-28_at_2.56.26_PM.png)
 
-We see that an array was returned with three elements in it, all of which are `<dt>` HTML elements.
+We see that a list of three elements was returned, all of which are `<dt>` HTML elements.
 
 So how then do we get just one of these `<dt>` elements? Specifically, we want to get the first one and make sure that the text says “4 Courses”.
 
-Since we are getting back an array, we can use a Cypress command called [eq](https://docs.cypress.io/api/commands/eq). This command will allow us to access a specific index within an array of elements, which is exactly what we want.
+Since we are getting back a list of elements, we can use a Cypress command called [eq](https://docs.cypress.io/api/commands/eq). This command will allow us to access a specific index within that list of elements, which is exactly what we want.
 
 :::info
-Remember that arrays start their indexes at 0, so the first element we want is 0 **not** 1.
+Remember that indexes start at 0, so the first element we want is 0 **not** 1.
 :::
 
 Update your test to the following:
@@ -526,7 +526,7 @@ Pay close attention to this line
 cy.get("dt").eq(0).contains("4 Courses")
 ```
 
-You can copy and paste this line with minor tweaks to test for the other features. You will need to reference the correct index in the array and update the text the feature contains.
+You can copy and paste this line with minor tweaks to test for the other features. You will need to reference the correct index in the list and update the text the feature contains.
 
 If you get stuck, the answer is below.
 

--- a/content/real-world-examples/overview/custom-cypress-commands.mdx
+++ b/content/real-world-examples/overview/custom-cypress-commands.mdx
@@ -183,7 +183,7 @@ return cy
   })
 ```
 
-This task can be found in `cypress/plugins/index.ts` .
+This task is registered in `setupNodeEvents` within the `e2e` block of `cypress.config.ts` .
 
 ```js
 on("task", {
@@ -1030,7 +1030,7 @@ cy.percySnapshot(snapshotTitle, {
 
 ## cy.task("db:seed")
 
-Located in `cypress/plugins/index.ts` .
+Registered in `setupNodeEvents` within the `e2e` block of `cypress.config.ts` .
 
 ```js
 async "db:seed"() {

--- a/content/tutorials/next-js-and-shopify-store/running-our-tests-in-parallel-with-cypress-dashboard.mdx
+++ b/content/tutorials/next-js-and-shopify-store/running-our-tests-in-parallel-with-cypress-dashboard.mdx
@@ -87,7 +87,7 @@ Save your changes and push them up to GitHub.
 
 ```bash
 git add .
-git commit -m "added Cypress dashboard projectID and env vars to GHA config"
+git commit -m "added Cypress Cloud projectID and env vars to GHA config"
 git push origin github-actions-cypress-tests
 ```
 
@@ -227,7 +227,7 @@ jobs:
           parallel: true
 ```
 
-Notice that we have added `parallel: true`. This tells the dashboard we want our tests to be run in parallel.
+Notice that we have added `parallel: true`. This tells Cypress Cloud we want our tests to be run in parallel.
 
 Finally, we add our environment variables and the entire workflow config should look like the following.
 

--- a/content/tutorials/next-js-and-shopify-store/writing-end-to-end-tests-with-cypress.mdx
+++ b/content/tutorials/next-js-and-shopify-store/writing-end-to-end-tests-with-cypress.mdx
@@ -55,11 +55,11 @@ Cypress should launch and look like this:
 
 ![Screen Shot 2021-12-16 at 10.09.25 AM.png](/images/tutorials/next-js-and-shopify-store/writing-end-to-end-tests-with-cypress/Screen_Shot_2021-12-16_at_10.09.25_AM.png)
 
-Cypress by default creates several example spec files for demonstration purposes. In the blue alert at the top click on the "No thanks, delete example files" link. This will delete all of the default spec files that Cypress installs upon first launching it.
+The first time you open Cypress you will see the Launchpad. Choose **E2E Testing**, and Cypress will scaffold a few configuration files for you. Click **Continue**, then pick a browser to start testing in.
 
 ## Writing Our First Test
 
-Create a new spec file within `cypress/integration` and called it `home.spec.js`
+Create a new spec file within `cypress/e2e` and called it `home.spec.js`
 
 ![Screen Shot 2022-05-09 at 11.00.19 AM.png](/images/tutorials/next-js-and-shopify-store/writing-end-to-end-tests-with-cypress/Screen_Shot_2022-05-09_at_11.00.19_AM.png)
 
@@ -272,7 +272,7 @@ Great all of our products are displaying the correct name and price!
 
 Let's now write some tests for the header of our application. We will write some tests to make sure that the links go to the correct pages and the search bar returns the correct results.
 
-First, create a new spec file in `cypress/integration` called `header.spec.js` and add the following.
+First, create a new spec file in `cypress/e2e` called `header.spec.js` and add the following.
 
 ```jsx
 describe("Header", () => {})
@@ -657,7 +657,7 @@ it.only("the search bar returns the correct search results", () => {
 
 Let's write one more test that confirms that our shopping cart is working.
 
-Create a new file within `cypress/integration` called `shopping-cart.spec.js` and add the following:
+Create a new file within `cypress/e2e` called `shopping-cart.spec.js` and add the following:
 
 ```jsx
 describe("Shopping Cart", () => {


### PR DESCRIPTION
- Correct have.css assertion to use separate property/value args
- Describe .find() as matching descendants, not direct children
- Refer to cy.get() results as a list of elements, not an array
- Update Shopify tutorial to cypress/e2e and the Launchpad onboarding flow
- Point db task docs to setupNodeEvents in cypress.config.ts (plugins dir removed in v10)
- Rename remaining "Cypress Dashboard" references to Cypress Cloud
- Clarify async/await, cy.clearCookies() chaining, and E2E vs integration wording

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019u1Tqo52vNwCFh4dZkBXBZ