### PR TITLE
docs: fix dev server and http/https inconsistencies in Cypress tutorial

### DIFF
--- a/content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx
+++ b/content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx
@@ -130,15 +130,20 @@ describe("home page", () => {
 })
 ```
 
+:::info
+Some of the screenshots in this lesson may show `https://localhost:3000`, but the course app runs over plain `http`. Be sure to use `http://localhost:3000` (without the **s**) so your test matches the app.
+:::
+
 Now let's run our test.
 
 :::info
-Remember, to launch Cypress enter the following in your terminal.
+If Cypress is still open from earlier in this lesson, you can keep using that same window—there's no need to launch it again. If you closed it, you can relaunch Cypress by entering the following in your terminal.
 
 ```bash
 npx cypress open
 ```
 
+Cypress can only control a single browser at a time, so avoid running more than one instance of Cypress at once. If a previous test is still running, close it before starting a new one.
 :::
 
 ![Screen Shot 2022-06-28 at 9.21.56 AM.png](/images/testing-your-first-application/installing-cypress-and-writing-your-first-test/Screen_Shot_2022-06-28_at_9.21.56_AM.png)
@@ -161,7 +166,11 @@ You should see the following.
 
 ## Debugging our first error
 
-Cypress is throwing an error and says that it cannot load **localhost:3000**. The reason this is happening is that our application's dev server is not running. When running our Cypress tests we always need to have our application's local dev server running. Otherwise, we are going to see this error.
+If your application's dev server is **not** running, Cypress will throw an error and say that it cannot load **localhost:3000**. The reason this happens is that our application's dev server is not running. When running our Cypress tests we always need to have our application's local dev server running. Otherwise, we are going to see this error.
+
+:::info
+If you still have the dev server running from the previous lesson (you started it with `npm run dev`), your test will already be passing and you won't see this error—you can skim this section and continue on. We're still walking through it because a missing dev server is one of the most common errors you'll run into, and it's important to understand why it happens.
+:::
 
 Since Cypress is currently running in our terminal like so:
 


### PR DESCRIPTION
Fixes #338

## Problem

The "Installing Cypress and writing your first test" lesson reads inconsistently for someone progressing lesson-to-lesson:

1. **http vs https** — The text instructs `cy.visit("http://localhost:3000")`, but the screenshots show `https://localhost:3000`, with no steps explaining a certificate setup.
2. **Dev server contradiction** — Lesson 1 has the user start the dev server (`npm run dev`) and leave it running, yet the "Debugging our first error" section assumes the server is *not* running so the test fails. A reader continuing lesson-to-lesson would actually see the test **pass**, making the debugging narrative confusing.
3. **Cypress already open** — After the install step, Cypress is still running, but the `npx cypress open` note reads as informational rather than a step, and users aren't warned that running a second instance/browser causes problems.

## Changes

In `content/courses/testing-your-first-application/installing-cypress-and-writing-your-first-test.mdx`:

- Added a note clarifying the app runs over plain **http**, so use `http://localhost:3000` (without the `s`) even though some screenshots show `https`.
- Reworked the launch note to say Cypress may still be open from earlier in the lesson (no need to relaunch), and that only one Cypress instance/browser should run at a time — close a running test before starting a new one.
- Updated "Debugging our first error" to acknowledge that a reader who kept the dev server running from the previous lesson will see the test already passing, while preserving the lesson's teaching about *why* the dev server is required.

## Out of scope

The reporter's 4th point — the "hidden element" icons / broken time-travel debugging — is an application bug tracked in the separate [`cypress-realworld-testing-course-app` repo (issue #33)](https://github.com/cypress-io/cypress-realworld-testing-course-app/issues/33) and can't be fixed from this content repo. The screenshots themselves still show `https` — they're static images that can't be regenerated here, so this adds a clarifying note instead; recapturing them could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmhoVoBHCfmW6zMQ7QCNDk)_